### PR TITLE
fix: wrap agent JSON parsing with contextual error message

### DIFF
--- a/loops/common/agent.py
+++ b/loops/common/agent.py
@@ -102,4 +102,8 @@ def agent(
         lines = text.splitlines()
         end = next((i for i in range(len(lines) - 1, 0, -1) if lines[i].strip() == "```"), None)
         text = "\n".join(lines[1:end] if end else lines[1:])
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"Agent ({prompt_file}) returned non-JSON output:\n{text}"
+        raise RuntimeError(msg) from exc

--- a/loops/tests/test_scan_agent.py
+++ b/loops/tests/test_scan_agent.py
@@ -16,3 +16,26 @@ def test_agent_raises_on_nonzero_returncode(tmp_path: Path) -> None:
         pytest.raises(RuntimeError, match="claude subprocess exited with return code 1"),
     ):
         agent("prompts/scan/sources/codebase/dead-code.md", "some context")
+
+
+def test_agent_raises_with_context_on_malformed_json(tmp_path: Path) -> None:
+    output_file = tmp_path / "agent_output.json"
+    output_file.touch()  # so the initial unlink() succeeds
+
+    proc_mock = MagicMock()
+    proc_mock.stdout = iter([])
+    proc_mock.returncode = 0
+    proc_mock.wait.side_effect = lambda: output_file.write_text("this is not json")
+
+    tmp_file_mock = MagicMock()
+    tmp_file_mock.name = str(output_file)
+    ntf_ctx = MagicMock()
+    ntf_ctx.__enter__ = MagicMock(return_value=tmp_file_mock)
+    ntf_ctx.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("loops.common.agent.subprocess.Popen", return_value=proc_mock),
+        patch("loops.common.agent.tempfile.NamedTemporaryFile", return_value=ntf_ctx),
+        pytest.raises(RuntimeError, match="non-JSON output"),
+    ):
+        agent("prompts/scan/sources/codebase/dead-code.md", "some context")


### PR DESCRIPTION
The `json.loads(text)` call at the end of `agent()` was unguarded — a bare `JSONDecodeError` with no indication of which step failed or what the raw output was.

Wrapped it in a `try/except` that re-raises as `RuntimeError` including the prompt file name and the raw output text.

The `StopIteration` case in `projects.py` was already handled (`next(..., None)` + `ValueError`) before this fix.

Added a test that verifies the error message contains "non-JSON output" when the agent writes malformed content to its output file.

Closes #2.